### PR TITLE
Fix attachment payload handling and improve chat attachment UX

### DIFF
--- a/backend/app/core/graph/members.py
+++ b/backend/app/core/graph/members.py
@@ -124,7 +124,34 @@ def format_messages(messages: list[AnyMessage]) -> str:
     """Format list of messages to string"""
     message_str: str = ""
     for message in messages:
-        message_str += f"{message.name}: {message.content}\n\n"
+        content = message.content
+        if isinstance(content, list):
+            formatted_parts: list[str] = []
+            for part in content:
+                if isinstance(part, str):
+                    formatted_parts.append(part)
+                    continue
+                if not isinstance(part, Mapping):
+                    continue
+
+                part_type = part.get("type")
+                if part_type == "text":
+                    text = part.get("text")
+                    if isinstance(text, str) and text:
+                        formatted_parts.append(text)
+                elif part_type == "image_url":
+                    formatted_parts.append("[Attached image]")
+                elif part_type == "file":
+                    filename = part.get("file", {}).get("filename")
+                    if isinstance(filename, str) and filename:
+                        formatted_parts.append(f"[Attached file: {filename}]")
+                    else:
+                        formatted_parts.append("[Attached file]")
+            message_content = "\n".join(formatted_parts)
+        else:
+            message_content = str(content)
+
+        message_str += f"{message.name}: {message_content}\n\n"
     return message_str
 
 

--- a/backend/app/tests/graph/test_members_format_messages.py
+++ b/backend/app/tests/graph/test_members_format_messages.py
@@ -1,0 +1,32 @@
+from langchain_core.messages import AnyMessage, HumanMessage
+
+from app.core.graph.members import format_messages
+
+
+def test_format_messages_hides_binary_attachment_payloads() -> None:
+    messages: list[AnyMessage] = [
+        HumanMessage(
+            name="user",
+            content=[
+                {"type": "text", "text": "Please analyze"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,AAAAAA"},
+                },
+                {
+                    "type": "file",
+                    "file": {
+                        "filename": "report.pdf",
+                        "file_data": "data:application/pdf;base64,BBBBBB",
+                    },
+                },
+            ],
+        )
+    ]
+
+    result = format_messages(messages)
+
+    assert "Please analyze" in result
+    assert "[Attached image]" in result
+    assert "[Attached file: report.pdf]" in result
+    assert "base64" not in result

--- a/frontend/src/components/Teams/ChatTeam.tsx
+++ b/frontend/src/components/Teams/ChatTeam.tsx
@@ -28,7 +28,7 @@ import { getRouteApi, useNavigate, useParams } from "@tanstack/react-router"
 import { useRef, useState } from "react"
 import { FaCheck, FaTimes } from "react-icons/fa"
 import { FaRegFileImage } from "react-icons/fa"
-import { FiCopy, FiPaperclip } from "react-icons/fi"
+import { FiCopy, FiFileText, FiPaperclip } from "react-icons/fi"
 import { GrFormNextLink } from "react-icons/gr"
 import { IoCreateOutline } from "react-icons/io5"
 import { VscSend } from "react-icons/vsc"
@@ -131,23 +131,38 @@ const MessageBox = ({ message, onResume }: MessageBoxProps) => {
       <Container pt={2}>
         {content && <Markdown content={content} />}
         {!!attachments?.length && (
-          <HStack spacing={2} mt={2} wrap="wrap">
-            {attachments.map((attachment, index) => (
-              <Tag
-                key={`${attachment.name}-${index}`}
-                size="sm"
-                colorScheme="blue"
-              >
-                <Icon
-                  as={
-                    attachment.type === "image" ? FaRegFileImage : FiPaperclip
-                  }
-                  mr={1}
-                />
-                <TagLabel>{attachment.name}</TagLabel>
-              </Tag>
-            ))}
-          </HStack>
+          <Box
+            mt={3}
+            p={3}
+            borderWidth="1px"
+            borderRadius="md"
+            borderColor="blue.200"
+            bg="blue.50"
+          >
+            <HStack spacing={2} mb={2}>
+              <Icon as={FiPaperclip} color="blue.600" />
+              <Text fontSize="sm" fontWeight="semibold" color="blue.700">
+                Вложений: {attachments.length}
+              </Text>
+            </HStack>
+            <HStack spacing={2} wrap="wrap">
+              {attachments.map((attachment, index) => (
+                <Tag
+                  key={`${attachment.name}-${index}`}
+                  size="sm"
+                  colorScheme={attachment.type === "image" ? "purple" : "blue"}
+                >
+                  <Icon
+                    as={
+                      attachment.type === "image" ? FaRegFileImage : FiFileText
+                    }
+                    mr={1}
+                  />
+                  <TagLabel>{attachment.name}</TagLabel>
+                </Tag>
+              ))}
+            </HStack>
+          </Box>
         )}
         {tool_calls?.map((tool_call, index) => (
           <Box key={index} mb={4}>
@@ -618,14 +633,40 @@ const ChatTeam = () => {
         </InputRightElement>
       </InputGroup>
       {files.length > 0 && (
-        <HStack spacing={2} mt={2} wrap="wrap">
-          {files.map((file, index) => (
-            <Tag key={`${file.name}-${index}`} size="sm" colorScheme="gray">
-              <TagLabel>{file.name}</TagLabel>
-              <TagCloseButton onClick={() => removeFile(index)} />
-            </Tag>
-          ))}
-        </HStack>
+        <Box
+          mt={2}
+          p={3}
+          borderWidth="1px"
+          borderRadius="md"
+          borderColor="gray.200"
+        >
+          <HStack spacing={2} mb={2}>
+            <Icon as={FiPaperclip} color="gray.600" />
+            <Text fontSize="sm" fontWeight="medium" color="gray.700">
+              Подготовлено вложений: {files.length}
+            </Text>
+          </HStack>
+          <HStack spacing={2} wrap="wrap">
+            {files.map((file, index) => {
+              const isImage =
+                file.type.startsWith("image/") ||
+                IMAGE_EXTENSIONS.some((extension) =>
+                  file.name.toLowerCase().endsWith(extension),
+                )
+              return (
+                <Tag
+                  key={`${file.name}-${index}`}
+                  size="sm"
+                  colorScheme={isImage ? "purple" : "gray"}
+                >
+                  <Icon as={isImage ? FaRegFileImage : FiFileText} mr={1} />
+                  <TagLabel>{file.name}</TagLabel>
+                  <TagCloseButton onClick={() => removeFile(index)} />
+                </Tag>
+              )
+            })}
+          </HStack>
+        </Box>
       )}
       <Box p={2} overflow={"auto"} height="72vh" my={2}>
         {messages.map((message, index) => (


### PR DESCRIPTION
### Motivation
- Prevent raw `data:*;base64,...` payloads from leaking into model prompts/history and being sent to providers. 
- Make attachments more discoverable and visually distinct in the chat UI so users can see when images/files are attached.

### Description
- Replace history formatting logic in `backend/app/core/graph/members.py` so multipart message parts are serialized to safe placeholders (text parts preserved, `image_url` -> `[Attached image]`, `file` -> `[Attached file: <filename>]`) and binary/base64 payloads are not included in the prompt string. 
- Add a regression test `backend/app/tests/graph/test_members_format_messages.py` that asserts formatted history contains placeholders and does not include `base64` payload substrings. 
- Improve chat attachment UI in `frontend/src/components/Teams/ChatTeam.tsx` by adding an attachment panel with a count, distinct icons for images vs files, and a highlighted pre-send preview area listing files with per-file icons and close controls. 

### Testing
- Ran backend linter: `cd backend && poetry run ruff check app/core/graph/members.py app/tests/graph/test_members_format_messages.py` (succeeded). 
- Ran static types: `cd backend && poetry run mypy app` (succeeded). 
- Ran frontend style check: `cd frontend && npx biome check src/components/Teams/ChatTeam.tsx` (succeeded). 
- Added and ran targeted pytest for formatting locally, but full `pytest` invocation in this environment fails due to missing required environment settings (DB and service env vars like `PROJECT_NAME`, `POSTGRES_*`, `QDRANT__SERVICE__API_KEY`, etc.), so tests that require full app settings could not be executed here. 
- Attempted a Playwright screenshot validation but the local frontend server was not running (`ERR_EMPTY_RESPONSE` to `http://127.0.0.1:5173`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994009b8d08832e841b417e60d428cc)